### PR TITLE
add setup docs and firmware script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,22 @@
+Development
+---
+
+### run
+
+```sh
+npm start
+```
+
+### test
+
+```sh
+npm t
+```
+
+### lint
+
+Checks for syntax errors and automatically formats code.
+
+```sh
+npm run lint
+```

--- a/SETUP.md
+++ b/SETUP.md
@@ -2,7 +2,7 @@
 
 How to build a curb wheel from scratch. Covers hardware and software.
 
-## Prep the measuring wheel
+## Prepare the measuring wheel
 
 The measuring wheel works by using a ["rotary encoder"](https://howtomechatronics.com/tutorials/arduino/rotary-encoder-works-use-arduino/), which is a set of [magnets and sensors](https://i.imgur.com/QDmhP2q.jpg) in its shaft. As the wheel turns, one of the magnets passes a sensor every 0.1 metres rolled, and a signal is sent up to the circuit board. These signals are added (when rolling forwards) and subtracted (when rolling backwards) to keep track of the distance rolled. We will be taking the wheel apart and sending these measurement signals to the Raspberry Pi instead.
 
@@ -61,32 +61,12 @@ When plugged in, the connector should look like this:
 
 ## Prepare the Micro SD card
 
-(placeholder for Morgan)
+1. Boot the Pi and connect to your local Wifi router
 
-## Load the map data for the area you are surveying
-
-(placeholder)
-
-
-
------
-
-## run
+2. Open your terminal (Linux of OSX), copy/paste the following command, and press enter:
 
 ```sh
-npm start
+curl https://raw.githubusercontent.com/sharedstreets/curb-wheel/master/setup.sh | sh
 ```
 
-## test
-
-```sh
-npm t
-```
-
-## lint
-
-Checks for syntax errors and automatically formats code.
-
-```sh
-npm run lint
-```
+3. The last step should print out a randomly generated WIFI name (ie: "CURBWHEEL-fYitIGnE") with a randomly generated password. Connect to this access point from your smartphone.

--- a/config/wpa_supplicant.conf.template
+++ b/config/wpa_supplicant.conf.template
@@ -1,0 +1,8 @@
+ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+country=us
+
+network={
+ ssid="[NAME OF WIFI NETWORK]"
+ psk="[WIFI NETWORK PASSWORD]"
+}

--- a/setup-ap.sh
+++ b/setup-ap.sh
@@ -1,0 +1,49 @@
+# SETUP WIFI ACCESS POINT
+# https://thepi.io/how-to-use-your-raspberry-pi-as-a-wireless-access-point/
+# https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md
+sudo apt install hostapd
+sudo apt install dnsmasq
+sudo systemctl stop hostapd
+sudo systemctl stop dnsmasq
+
+echo "interface wlan0"  >> /etc/dhcpcd.conf
+echo "static ip_address=192.168.0.10/24"  >> /etc/dhcpcd.conf
+echo "denyinterfaces eth0"  >> /etc/dhcpcd.conf
+echo "denyinterfaces wlan0"  >> /etc/dhcpcd.conf
+
+echo "interface=wlan0" >> /etc/dnsmasq.conf
+echo "  dhcp-range=192.168.0.11,192.168.0.30,255.255.255.0,24h" >> /etc/dnsmasq.conf
+
+ssid="CURBWHEEL-$(openssl rand -base64 6)"
+password=$(openssl rand -base64 8)
+
+echo "interface=wlan0" >> /etc/hostapd/hostapd.conf
+echo "bridge=br0" >> /etc/hostapd/hostapd.conf
+echo "hw_mode=g" >> /etc/hostapd/hostapd.conf
+echo "channel=7" >> /etc/hostapd/hostapd.conf
+echo "wmm_enabled=0" >> /etc/hostapd/hostapd.conf
+echo "macaddr_acl=0" >> /etc/hostapd/hostapd.conf
+echo "auth_algs=1" >> /etc/hostapd/hostapd.conf
+echo "ignore_broadcast_ssid=0" >> /etc/hostapd/hostapd.conf
+echo "wpa=2" >> /etc/hostapd/hostapd.conf
+echo "wpa_key_mgmt=WPA-PSK" >> /etc/hostapd/hostapd.conf
+echo "wpa_pairwise=TKIP" >> /etc/hostapd/hostapd.conf
+echo "rsn_pairwise=CCMP" >> /etc/hostapd/hostapd.conf
+echo "ssid=CURBWHEEL-$ssid" >> /etc/hostapd/hostapd.conf
+echo "wpa_passphrase=$password" >> /etc/hostapd/hostapd.conf
+
+echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" >> /etc/default/hostapd
+
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+
+sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+sudo sh -c "iptables-save > /etc/iptables.ipv4.nat"
+
+echo "" > /etc/rc.local
+echo "#!/bin/sh -e" >> /etc/rc.local
+echo "iptables-restore < /etc/iptables.ipv4.nat" >> /etc/rc.local
+echo "exit 0" >> /etc/rc.local
+
+echo "---"
+echo "WIFI: $ssid"
+echo "PASSWORD: $password"

--- a/setup-wifi.sh
+++ b/setup-wifi.sh
@@ -1,4 +1,4 @@
 # edit config/wpa_supplicant.conf.template 
 # file to include local network name and password
 
-sudo cp config/wpa_supplicant.conf.template /etc/wpa/wpa_supplicant.conf
+sudo cp config/wpa_supplicant.conf.template /etc/wpa_supplicant/wpa_supplicant.conf

--- a/setup-wifi.sh
+++ b/setup-wifi.sh
@@ -1,0 +1,4 @@
+# edit config/wpa_supplicant.conf.template 
+# file to include local network name and password
+
+sudo cp config/wpa_supplicant.conf.template /etc/wpa/wpa_supplicant.conf

--- a/setup.sh
+++ b/setup.sh
@@ -7,52 +7,8 @@ sudo apt upgrade
 # INSTALL NODE & NPM
 sudo apt install nodejs npm
 
-# SETUP WIFI ACCESS POINT
-# https://thepi.io/how-to-use-your-raspberry-pi-as-a-wireless-access-point/
-# https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md
-sudo apt install hostapd
-sudo apt install dnsmasq
-sudo systemctl stop hostapd
-sudo systemctl stop dnsmasq
+# SETUP AP MODE (production deployment)
+sh setup-ap.sh
 
-echo "interface wlan0"  >> /etc/dhcpcd.conf
-echo "static ip_address=192.168.0.10/24"  >> /etc/dhcpcd.conf
-echo "denyinterfaces eth0"  >> /etc/dhcpcd.conf
-echo "denyinterfaces wlan0"  >> /etc/dhcpcd.conf
-
-echo "interface=wlan0" >> /etc/dnsmasq.conf
-echo "  dhcp-range=192.168.0.11,192.168.0.30,255.255.255.0,24h" >> /etc/dnsmasq.conf
-
-ssid="CURBWHEEL-$(openssl rand -base64 6)"
-password=$(openssl rand -base64 8)
-
-echo "interface=wlan0" >> /etc/hostapd/hostapd.conf
-echo "bridge=br0" >> /etc/hostapd/hostapd.conf
-echo "hw_mode=g" >> /etc/hostapd/hostapd.conf
-echo "channel=7" >> /etc/hostapd/hostapd.conf
-echo "wmm_enabled=0" >> /etc/hostapd/hostapd.conf
-echo "macaddr_acl=0" >> /etc/hostapd/hostapd.conf
-echo "auth_algs=1" >> /etc/hostapd/hostapd.conf
-echo "ignore_broadcast_ssid=0" >> /etc/hostapd/hostapd.conf
-echo "wpa=2" >> /etc/hostapd/hostapd.conf
-echo "wpa_key_mgmt=WPA-PSK" >> /etc/hostapd/hostapd.conf
-echo "wpa_pairwise=TKIP" >> /etc/hostapd/hostapd.conf
-echo "rsn_pairwise=CCMP" >> /etc/hostapd/hostapd.conf
-echo "ssid=CURBWHEEL-$ssid" >> /etc/hostapd/hostapd.conf
-echo "wpa_passphrase=$password" >> /etc/hostapd/hostapd.conf
-
-echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" >> /etc/default/hostapd
-
-echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
-
-sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
-sudo sh -c "iptables-save > /etc/iptables.ipv4.nat"
-
-echo "" > /etc/rc.local
-echo "#!/bin/sh -e" >> /etc/rc.local
-echo "iptables-restore < /etc/iptables.ipv4.nat" >> /etc/rc.local
-echo "exit 0" >> /etc/rc.local
-
-echo "---"
-echo "WIFI: $ssid"
-echo "PASSWORD: $password"
+# SETUP LOCAL WIFI MODE (development deployment)
+# sh setup-wifi.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,58 @@
+# curl https://raw.githubusercontent.com/sharedstreets/curb-wheel/master/setup.sh | sh
+
+# UPDATE DEPENDENCIES
+sudo apt update
+sudo apt upgrade
+
+# INSTALL NODE & NPM
+sudo apt install nodejs npm
+
+# SETUP WIFI ACCESS POINT
+# https://thepi.io/how-to-use-your-raspberry-pi-as-a-wireless-access-point/
+# https://www.raspberrypi.org/documentation/configuration/wireless/access-point.md
+sudo apt install hostapd
+sudo apt install dnsmasq
+sudo systemctl stop hostapd
+sudo systemctl stop dnsmasq
+
+echo "interface wlan0"  >> /etc/dhcpcd.conf
+echo "static ip_address=192.168.0.10/24"  >> /etc/dhcpcd.conf
+echo "denyinterfaces eth0"  >> /etc/dhcpcd.conf
+echo "denyinterfaces wlan0"  >> /etc/dhcpcd.conf
+
+echo "interface=wlan0" >> /etc/dnsmasq.conf
+echo "  dhcp-range=192.168.0.11,192.168.0.30,255.255.255.0,24h" >> /etc/dnsmasq.conf
+
+ssid="CURBWHEEL-$(openssl rand -base64 6)"
+password=$(openssl rand -base64 8)
+
+echo "interface=wlan0" >> /etc/hostapd/hostapd.conf
+echo "bridge=br0" >> /etc/hostapd/hostapd.conf
+echo "hw_mode=g" >> /etc/hostapd/hostapd.conf
+echo "channel=7" >> /etc/hostapd/hostapd.conf
+echo "wmm_enabled=0" >> /etc/hostapd/hostapd.conf
+echo "macaddr_acl=0" >> /etc/hostapd/hostapd.conf
+echo "auth_algs=1" >> /etc/hostapd/hostapd.conf
+echo "ignore_broadcast_ssid=0" >> /etc/hostapd/hostapd.conf
+echo "wpa=2" >> /etc/hostapd/hostapd.conf
+echo "wpa_key_mgmt=WPA-PSK" >> /etc/hostapd/hostapd.conf
+echo "wpa_pairwise=TKIP" >> /etc/hostapd/hostapd.conf
+echo "rsn_pairwise=CCMP" >> /etc/hostapd/hostapd.conf
+echo "ssid=CURBWHEEL-$ssid" >> /etc/hostapd/hostapd.conf
+echo "wpa_passphrase=$password" >> /etc/hostapd/hostapd.conf
+
+echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" >> /etc/default/hostapd
+
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+
+sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+sudo sh -c "iptables-save > /etc/iptables.ipv4.nat"
+
+echo "" > /etc/rc.local
+echo "#!/bin/sh -e" >> /etc/rc.local
+echo "iptables-restore < /etc/iptables.ipv4.nat" >> /etc/rc.local
+echo "exit 0" >> /etc/rc.local
+
+echo "---"
+echo "WIFI: $ssid"
+echo "PASSWORD: $password"

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,13 @@
+const test = require("tap").test;
+const path = require("path");
+const app = require("../src/index");
+
+test("server", async (t) => {
+  let server = await app();
+
+  t.ok(server, "app server created");
+  server.close();
+  t.pass("server closed gracefully");
+
+  t.done();
+});


### PR DESCRIPTION
- implements `setup.sh`, which allows one-liner installation of dependencies by streaming the script to bash
- adds firmware setup instructions to `SETUP.md`
- creates `DEVELOPMENT.md` doc for describing important dev info, such as running tests
- removed map extract section - this needs to be part of general usage docs

## Todo

- Has not been tested on a Pi yet. **CAUTION:** _very_ likely to brick your Pi!
- Add installation of curb-wheel server, and code to run the daemon on start
- Recommend `reboot` at end of docs?