### PR TITLE
survey backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,13 @@
     "url": "git+https://github.com/sharedstreets/curb-wheel.git"
   },
   "author": "Emily Eros",
-  "contributors": ["Emily Eros", "Kevin Webb", "Mollie McArdle", "Morgan Herlocker", "Peter Liu"],
+  "contributors": [
+    "Emily Eros",
+    "Kevin Webb",
+    "Mollie McArdle",
+    "Morgan Herlocker",
+    "Peter Liu"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/sharedstreets/curb-wheel/issues"

--- a/src/graph.js
+++ b/src/graph.js
@@ -18,6 +18,7 @@ function Graph() {
   this.bounds = [-Infinity, -Infinity, Infinity, Infinity];
   this.center = [0, 0];
   this.index = {};
+  this.surveys = new Map();
   this.loaded = false;
 }
 
@@ -35,12 +36,16 @@ Graph.prototype.query = async function (bbox) {
 };
 
 Graph.prototype.save = async function (file) {
-  let copy = {
-    streets: this.streets,
-    bounds: this.bounds,
-    center: this.center,
-    index: this.index.toJSON(),
-  };
+  let copy = {};
+  copy.streets = this.streets;
+  copy.bounds = this.bounds;
+  copy.center = this.center;
+  copy.index = this.index.toJSON();
+  copy.surveys = {};
+  for (const [key, value] of this.surveys) {
+    copy.surveys[key] = value;
+  }
+
   await writeFileAsync(file, JSON.stringify(copy));
 };
 
@@ -51,6 +56,10 @@ Graph.prototype.load = async function (file) {
   this.bounds = data.bounds;
   this.center = data.center;
   this.index = new RBush().fromJSON(data.index);
+  this.surveys = new Map();
+  for (const key of Object.keys(data.surveys)) {
+    this.surveys.set(key, data.surveys[key]);
+  }
   this.loaded = true;
 };
 
@@ -146,6 +155,7 @@ Graph.prototype.extract = async function (pbf) {
           k++;
         }
         this.index = index;
+        this.surveys = new Map();
 
         return resolve(this);
       });

--- a/src/server.js
+++ b/src/server.js
@@ -140,17 +140,13 @@ async function main() {
     });
 
     app.get("/surveys/:ref", async (req, res) => {
-      console.log("GET SURVEYS");
       let ref = req.params.ref;
       let surveys = app.state.graph.surveys.get(ref);
       if (!surveys) {
         surveys = [];
       }
 
-      console.log(ref);
-      console.log(surveys);
-
-      res.status(200).send("surveys");
+      res.status(200).send(surveys);
     });
 
     app.post("/surveys/:ref", async (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -18,6 +18,7 @@ async function main() {
 
     // middleware
     app.use(fileUpload());
+    app.use(express.json());
 
     // application state
     app.state = {};
@@ -138,8 +139,30 @@ async function main() {
       });
     });
 
-    app.post("/survey", async (req, res) => {
-      // todo: save to edge index
+    app.get("/surveys/:ref", async (req, res) => {
+      console.log("GET SURVEYS");
+      let ref = req.params.ref;
+      let surveys = app.state.graph.surveys.get(ref);
+      if (!surveys) {
+        surveys = [];
+      }
+
+      console.log(ref);
+      console.log(surveys);
+
+      res.status(200).send("surveys");
+    });
+
+    app.post("/surveys/:ref", async (req, res) => {
+      let ref = req.params.ref;
+      let surveys = app.state.graph.surveys.get(ref);
+      if (!surveys) {
+        surveys = [];
+      }
+
+      surveys.push(req.body);
+      app.state.graph.surveys.set(ref, surveys);
+
       res.status(200).send("Uploaded survey.");
     });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -7,6 +7,7 @@ const rimraf = require("rimraf");
 const app = require("../src/server");
 
 request.post = util.promisify(request.post);
+request.get = util.promisify(request.get);
 
 test("server", async (t) => {
   let server = await app();
@@ -91,20 +92,28 @@ test("server", async (t) => {
 
   let survey = {};
   let ref = "123";
-  /*let saved = await request.post({
+  let saved = await request.post({
     url: "http://localhost:8081/surveys/" + ref,
-    headers: {"Content-Type": "application/json"},
-    body: JSON.stringify({ok:1})
-  })*/
-
-  //t.equal(saved.statusCode, 200, "survey save returned valid status code 200");
-
-  let surveysResponse = await request.get({
-    url: "http://localhost:8081/surveys/" + ref,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ok: 1 }),
   });
 
-  //t.equal(surveysResponse.statusCode, 200, "surveys get returned valid status code 200");
-  //console.log(surveysResponse.body)
+  t.equal(saved.statusCode, 200, "survey save returned valid status code 200");
+
+  let surveysResponse = await request.get(
+    "http://localhost:8081/surveys/" + ref
+  );
+
+  t.equal(
+    surveysResponse.statusCode,
+    200,
+    "surveys get returned valid status code 200"
+  );
+  t.equal(
+    surveysResponse.body,
+    JSON.stringify([{ ok: 1 }]),
+    "surveys matched uploaded data"
+  );
 
   // clean up
   server.close();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -89,6 +89,24 @@ test("server", async (t) => {
   t.equal(upload3.statusCode, 200, "upload 3 returned valid status code 200");
   t.equal(upload4.statusCode, 200, "upload 4 returned valid status code 200");
 
+  let survey = {};
+  let ref = "123";
+  /*let saved = await request.post({
+    url: "http://localhost:8081/surveys/" + ref,
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({ok:1})
+  })*/
+
+  //t.equal(saved.statusCode, 200, "survey save returned valid status code 200");
+
+  let surveysResponse = await request.get({
+    url: "http://localhost:8081/surveys/" + ref,
+  });
+
+  //t.equal(surveysResponse.statusCode, 200, "surveys get returned valid status code 200");
+  //console.log(surveysResponse.body)
+
+  // clean up
   server.close();
   rimraf.sync(path.join(__dirname, "../static/images/survey"));
 


### PR DESCRIPTION
This PR implements:

- adds `surveys` Map lookup to the graph
- surveys serialization and deserialization
- POST surveys for uploading a new survey to a sharedstreets ref
- GET surveys for retrieving all surveys collected for a sharedstreets ref
- tests for the new server endpoints

# todo

- [x] working through last bug with the GET surveys endpoint