### PR TITLE
adding new counter/wheel apis

### DIFF
--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -10,6 +10,7 @@ const writeFileAsync = promisify(fs.writeFile);
 const unlinkAsync = promisify(fs.unlink);
 
 test("graph", async (t) => {
+
   const pbf = path.join(__dirname, "./fixtures/honolulu.osm.pbf");
 
   let graph = new Graph();

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -7,8 +7,10 @@ const rimraf = require("rimraf");
 const app = require("../src/server");
 
 request.post = util.promisify(request.post);
+request.get = util.promisify(request.get);
 
 test("server", async (t) => {
+
   let server = await app();
 
   t.ok(server, "app server created");
@@ -88,9 +90,204 @@ test("server", async (t) => {
   t.equal(upload2.statusCode, 200, "upload 2 returned valid status code 200");
   t.equal(upload3.statusCode, 200, "upload 3 returned valid status code 200");
   t.equal(upload4.statusCode, 200, "upload 4 returned valid status code 200");
+  
+  server.close();
+  rimraf.sync(path.join(__dirname, "../static/images/survey"));
+
+  t.ok("server closed gracefully");
+
+  t.done();
+});
+
+
+
+test("wheel", async (t) => {
+
+  let server = await app();
+
+  t.ok(server, "app server created")
+
+  // testing counter -- this will fail if simulator or live wheel python code is running and overwrites test values
+
+  // zero counter for testing
+  let setWheel1 = await request
+    .post({
+      url: "http://localhost:8081/wheel",
+      formData: {
+        counter: 0,
+      },
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(setWheel1.statusCode, 200, "returned a valid response code");
+
+
+  let getWheel1 = await request
+    .get({
+      url: "http://localhost:8081/wheel"
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(JSON.parse(getWheel1.body).counter, 0, "wheel returned correct value");
+
+  let getCounter1 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(getCounter1.statusCode, 200, "returned a valid response code");
+  t.equal(JSON.parse(getCounter1.body).counter, 0, "returned the correct counter value");
+
+  let getCounter1a = await request
+    .get("http://localhost:8081/counter/full-count")
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(getCounter1a.statusCode, 200, "returned a valid response code");
+  t.equal(JSON.parse(getCounter1a.body).counter, 0, "returned the correct counter value");
+
+  let setWheel2 = await request
+    .post({
+      url: "http://localhost:8081/wheel",
+      formData: {
+        counter: 10
+      },
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  let getWheel2 = await request
+    .get({
+      url: "http://localhost:8081/wheel"
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(JSON.parse(getWheel2.body).counter, 10, "wheel returned correct value");
+
+  let getCounter2 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter2.body).counter, 10, "returned the correct counter value");
+
+
+  let puaseCounter3 = await request
+    .post({
+      url: "http://localhost:8081/counter/pause",
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+  
+  let setWheel3 = await request
+    .post({
+      url: "http://localhost:8081/wheel",
+      formData: {
+        counter: 20
+      },
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  let getCounter3 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter3.body).counter, 10, "returned the correct counter value");
+
+  let resumeCounter4 = await request
+    .post({
+      url: "http://localhost:8081/counter/resume",
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  let setWheel4 = await request
+    .post({
+      url: "http://localhost:8081/wheel",
+      formData: {
+        counter: 30
+      },
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+
+  let getCounter4 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter4.body).counter, 20, "returned the correct counter value");
+
+  let getCounter4a = await request
+    .get("http://localhost:8081/counter/full-count")
+    .catch((err) => {
+      if (err) throw err;
+    });
+  t.equal(getCounter4a.statusCode, 200, "returned a valid response code");
+  t.equal(JSON.parse(getCounter4a.body).counter, 30, "returned the correct counter value");
+
+  let resetCounter5 = await request
+    .post({
+      url: "http://localhost:8081/counter/reset",
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+
+  let getCounter5 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter5.body).counter, 0, "returned the correct counter value");
+
+  let setWheel5 = await request
+    .post({
+      url: "http://localhost:8081/wheel",
+      formData: {
+        counter: 40
+      },
+    })
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  let getCounter6 = await request
+    .get("http://localhost:8081/counter")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter6.body).counter, 10, "returned the correct counter value");
+
+  let getCounter6a = await request
+    .get("http://localhost:8081/counter/full-count")
+    .catch((err) => {
+      if (err) throw err;
+    });
+
+  t.equal(JSON.parse(getCounter6a.body).counter, 40, "returned the correct counter value");
 
   server.close();
   rimraf.sync(path.join(__dirname, "../static/images/survey"));
+
+
 
   t.ok("server closed gracefully");
 


### PR DESCRIPTION
Added the following new wheel and counter API's

```
GET /wheel  - returns the current raw wheel sensor value
POST /wheel - sets the raw wheel sensor value (primarily for testing)

GET /counter/(counterId?) - gets the current counter value with an optional counter id
POST /counter/(counterId?)/pause - pause incrementing the counter value with an optional counter id
POST /counter/(counterId?)/resume - resumes incrementing the counter value with an optional counter id
POST /counter/(counterId?)/reset -zeros the counter value with an optional counter id
```