### PR TITLE
change tileserver url to absolute address

### DIFF
--- a/static/map.js
+++ b/static/map.js
@@ -3,7 +3,7 @@ mapboxgl.accessToken =
 
 app.ui.map = new mapboxgl.Map({
 	container: "map",
-	style: "http://[::]:8080/styles/basic-preview/style.json",
+	style: "http://10.3.141.1:8080/styles/basic-preview/style.json",
 	hash: true,
 });
 


### PR DESCRIPTION
this PR changes the tileserver url to an absolute url. This updates allows all changes since r8 to be included in a working version with the exception of:

* geolocation puck

