### PR TITLE
swap flatbush for RBush

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,19 +3063,6 @@
       "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
       "dev": true
     },
-    "flatbush": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-3.2.1.tgz",
-      "integrity": "sha512-RAqcCyM18R0HhGIcZ7nTRImHnvmJAQqxSN8VIrRLPyWDuFjxluiyE99wuDqFiwNwBodlHXBQNf/9CrlfSqJq2A==",
-      "requires": {
-        "flatqueue": "^1.2.0"
-      }
-    },
-    "flatqueue": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-1.2.0.tgz",
-      "integrity": "sha512-Z/nhmRwSywE3xnHXHqbLzJiUZ9akOHZlB1IIqCzRRldWrxqp6EzqGVxTl9Fl5cSoUzC5ge7xq3WIPct8ADYdhw=="
-    },
     "flow-parser": {
       "version": "0.121.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.121.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "copy-dir": "^1.3.0",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.6",
-    "flatbush": "^3.2.1",
     "level": "^6.0.1",
     "osm-pbf-parser": "^2.3.0",
+    "rbush": "^3.0.1",
     "request": "^2.88.2",
     "sharedstreets": "^0.15.1",
     "through2": "^3.0.1"


### PR DESCRIPTION
We're using RBush for our R-Tree but package.json included flatbush from a previous implementation.  This seems to have switched over around here: https://github.com/sharedstreets/curb-wheel/pull/33

This hasn't created any bugs because the I assume the node_modules directed is getting copied over you dont currently notice it because we aren't explicitly running ```npm install```. For future builds this will correct the dependencies.